### PR TITLE
Add `showForSingleQuality` config to `qualitySelector`

### DIFF
--- a/src/plugins/es.upv.paella.qualitySelector.js
+++ b/src/plugins/es.upv.paella.qualitySelector.js
@@ -33,7 +33,7 @@ export default class QualitySelectorPlugin extends MenuButtonPlugin {
 
         this._qualities = await this.player.videoContainer.streamProvider.getQualities();
 
-        return this._qualities && this._qualities.length>1;
+        return this._qualities && (this.config.showForSingleQuality || this._qualities.length > 1);
     }
 
     async load() {


### PR DESCRIPTION
Sometimes it makes sense to show the quality selector even if there is only one quality to select from. This shows the user the current quality for example. But it is also about consistency, so that the user can always expect there to be this selector, otherwise users might be confused by it missing. This is especially relevant if you move the quality selector into a submenu: if the quality selector randomly disappears, the submenu might end up empty, which looks very weird. So in these cases, it is beneficial to just always show it.

Once this is accepted, I will open another PR against paella-core to update the documentation.